### PR TITLE
minor chores

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,13 @@ jobs:
             --minify \
             --baseURL "https://andrewbolster.info/"
 
+      - name: Check no scratch directory
+        run: |
+          if [ -d "scratch" ]; then
+            echo "ERROR: scratch/ directory must be removed before merging to master"
+            exit 1
+          fi
+
       - name: Verify build output
         run: |
           echo "Build completed successfully"

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ resume/*.out
 resume/*.xml
 resume/*.pdf
 
+# Scratch 
+scratch/
+
 # Ruby (legacy)
 Gemfile.lock
 .bundle/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,12 @@ make precommit
 - **themes/PaperMod/**: PaperMod theme (git submodule)
 - **archetypes/**: Templates for new content
 - **public/**: Generated static site (excluded from git)
+- **scratch/**: Temporary research and working notes for Claude Code agents
+
+### Scratch Directory Usage
+Use `scratch/` for research notes, source documents, link lists, and working files when drafting posts. This keeps research traceable and avoids polluting the repo root.
+
+**Critical**: The `scratch/` directory **must be deleted before merging any branch to master**. The CI workflow enforces this — PRs will fail if `scratch/` is present. Clean it up as the final step before raising a PR.
 
 ### Theme
 - Uses PaperMod theme (https://github.com/adityatelange/hugo-PaperMod)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 .PHONY: install update draft publish serve build clean precommit all
 
+HUGO := uvx hugo
+
 # Install Hugo (assumes brew on macOS, or provides instructions)
 install:
 	@echo "Installing Hugo..."
@@ -27,7 +29,10 @@ update:
 # Create a new draft post
 draft:
 	@read -p "Enter the title of the draft: " title; \
-	hugo new content/posts/$$(date +%Y-%m-%d)-$$(echo "$$title" | tr '[:upper:]' '[:lower:]' | tr ' ' '-').md
+	slug=$$(echo "$$title" | tr '[:upper:]' '[:lower:]' | tr ' ' '-' | tr -cd '[:alnum:]-'); \
+	filepath="content/posts/$$(date +%Y-%m-%d)-$$slug.md"; \
+	$(HUGO) new "$$filepath"; \
+	sed -i '' "s/^title:.*/title: \"$$title\"/" "$$filepath"
 
 # Publish drafts (move from draft: true to draft: false)
 # In Hugo, drafts are controlled by front matter, not directory location
@@ -37,11 +42,11 @@ publish:
 
 # Serve the site locally with drafts
 serve:
-	hugo server --buildDrafts --buildFuture --navigateToChanged
+	$(HUGO) server --buildDrafts --buildFuture --navigateToChanged
 
 # Build the production site
 build:
-	hugo --gc --minify
+	$(HUGO) --gc --minify
 
 # Clean generated files
 clean:


### PR DESCRIPTION
## Summary
CI/UX improvements for managing temporary working files and streamlining Hugo commands.

## Changes
- **Scratch directory management**: Add `scratch/` to `.gitignore` for temporary research and working notes
- **CI enforcement**: Add GitHub Actions check to prevent `scratch/` from being committed to master
- **Developer docs**: Document scratch directory usage and cleanup requirements in CLAUDE.md
- **Hugo tooling**: Update Makefile to use `uvx hugo` (universal package exec) instead of direct `hugo` command
- **Draft creation**: Enhance `make draft` to properly handle title slugification and set the correct title in front matter

## Why
- Provides a safe place for Claude Code agents to keep research and working files during post drafting
- Prevents accidental commits of temporary scratch files to the main branch
- Improves developer experience with standardized commands and better draft post creation

## Checklist
- ✅ Added CI check for scratch directory
- ✅ Updated documentation
- ✅ Enhanced Makefile with better Hugo integration