### PR TITLE
Add Machine.news article to about.md engagements

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -45,6 +45,7 @@ A sucker for Doctor Who, Scottish and Japanese Whiskey, Craft Beer, any movies i
 
 ## Engagements and Publications
 * 2026
+  * :fountain_pen: ["AI didn't invent new classes of risk. It poured fuel onto existing ones."](https://www.machine.news/ai-classes-of-risk-it-poured-fuel-onto-existing-ones/) - Machine - Author
   * :fountain_pen: [The Code Doesn't Care Who Wrote It: Why Context, Not AI Fear, Will Define Modern Application Security](https://devops.com/the-code-doesnt-care-who-wrote-it-why-context-not-ai-fear-will-define-modern-application-security/) - DevOps.com - Author
   * :speaking_head: [Embrace AI Coding Assistants While Efficiently Managing Risk](https://www.techshowlondon.co.uk/tech-show-london-2026-programme/embrace-ai-coding-assistants-while-efficiently-managing-risk) - [Tech Show London / DevOps Live 2026](https://www.techshowlondon.co.uk/) - Speaker
   * :speaking_head: Dr. StrangeBot: How I Learned to Stop Worrying & Love Diverse Security Data - RSA Conference 2026 - Speaker

--- a/content/about.md
+++ b/content/about.md
@@ -45,10 +45,10 @@ A sucker for Doctor Who, Scottish and Japanese Whiskey, Craft Beer, any movies i
 
 ## Engagements and Publications
 * 2026
-  * :fountain_pen: ["AI didn't invent new classes of risk. It poured fuel onto existing ones."](https://www.machine.news/ai-classes-of-risk-it-poured-fuel-onto-existing-ones/) - Machine - Author
-  * :fountain_pen: [The Code Doesn't Care Who Wrote It: Why Context, Not AI Fear, Will Define Modern Application Security](https://devops.com/the-code-doesnt-care-who-wrote-it-why-context-not-ai-fear-will-define-modern-application-security/) - DevOps.com - Author
-  * :speaking_head: [Embrace AI Coding Assistants While Efficiently Managing Risk](https://www.techshowlondon.co.uk/tech-show-london-2026-programme/embrace-ai-coding-assistants-while-efficiently-managing-risk) - [Tech Show London / DevOps Live 2026](https://www.techshowlondon.co.uk/) - Speaker
   * :speaking_head: Dr. StrangeBot: How I Learned to Stop Worrying & Love Diverse Security Data - RSA Conference 2026 - Speaker
+  * :speaking_head: [Embrace AI Coding Assistants While Efficiently Managing Risk](https://www.techshowlondon.co.uk/tech-show-london-2026-programme/embrace-ai-coding-assistants-while-efficiently-managing-risk) - [Tech Show London / DevOps Live 2026](https://www.techshowlondon.co.uk/) - Speaker
+  * :fountain_pen: [The Code Doesn't Care Who Wrote It: Why Context, Not AI Fear, Will Define Modern Application Security](https://devops.com/the-code-doesnt-care-who-wrote-it-why-context-not-ai-fear-will-define-modern-application-security/) - DevOps.com - Author
+  * :fountain_pen: ["AI didn't invent new classes of risk. It poured fuel onto existing ones."](https://www.machine.news/ai-classes-of-risk-it-poured-fuel-onto-existing-ones/) - Machine - Author
   * :speech_balloon: [Researchers hijack popular AI agents from Anthropic, Google, and Microsoft: vendors choose to stay silent](https://cybernews.com/security/ai-agents-github-prompt-injection-pattern/) - Cybernews - Commentary
   * :speech_balloon: [Researchers Say Claude Flaws Could Be Chained to Silently Exfiltrate User Data](https://securitybuzz.com/cybersecurity-news/researchers-say-claude-flaws-could-be-chained-to-silently-exfiltrate-user-data/) - SecurityBuzz - Commentary
   * :speech_balloon: [New research from Check Point has uncovered critical vulnerabilities in Claude Code](https://www.mbtmag.com/cybersecurity/article/22961480/new-research-from-check-point-has-uncovered-critical-vulnerabilities-in-claude-code) - Manufacturing Business Technology - Commentary


### PR DESCRIPTION
## Summary

- Adds Machine.news article to the Engagements and Publications section of about.md

## Test plan

- [ ] Verify about.md renders correctly locally (`make serve`)
- [ ] Confirm new entry appears in the Engagements section