### PR TITLE
Fix CLAUDE.md URL docs, normalise tag casing, resolve slug collisions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,9 +95,22 @@ Posts follow Hugo naming convention: `YYYY-MM-DD-title.md`
 - Asset files organized by year in `static/img/`
 
 ### URL Structure
-Posts use permalink pattern: `/:year/:month/:title.html`
-- Example: `/2024/02/my-post-title.html`
+Posts use the permalink pattern configured in `hugo.toml`: `/:year/:month/:title`
+- Example: `/2024/02/my-post-title/`
 - Preserves legacy Jekyll URL structure for SEO
+
+**`:title` slugifies the post's TITLE, not its filename.** Where a filename is a
+shortened version of the title, the two differ and the filename-derived URL 404s.
+Always derive an internal link from the target's `title:` front matter, and verify
+it against a built site rather than assuming a file's existence means the URL works.
+
+Punctuation in a title survives into the slug. A title ending in a full stop
+produces a trailing dot in the URL (e.g. `.../its-reflections-are./`).
+
+`slug:` does **not** override this — with a `:title` pattern Hugo never consults it.
+(Posts that set `slug:` only appear to work because their slug matches their
+title's slugified form.) To pin a URL, set `url:` in front matter, and add an
+`aliases:` entry if the old URL was already published.
 
 ### Static Assets
 - `static/img/`: Images organized by year and topic

--- a/content/posts/2008-05-12-asus-eeepc.md
+++ b/content/posts/2008-05-12-asus-eeepc.md
@@ -8,7 +8,7 @@ tags:
 - EeePC
 - Linux
 - Ubuntu
-- customer service
+- Customer Service
 title: Asus EEEpc
 ---
 

--- a/content/posts/2008-09-14-long-extended-break-hardware-update.md
+++ b/content/posts/2008-09-14-long-extended-break-hardware-update.md
@@ -11,7 +11,7 @@ tags:
 - Perl
 - Router
 - Ubuntu
-- remote access
+- Remote Access
 title: 'Long Extended Break: Hardware Update'
 ---
 

--- a/content/posts/2008-10-25-getting-skype-to-work-with-weird-webcams.md
+++ b/content/posts/2008-10-25-getting-skype-to-work-with-weird-webcams.md
@@ -7,7 +7,7 @@ slug: getting-skype-to-work-with-weird-webcams
 tags:
 - Linux
 - Ubuntu
-- webcam
+- Webcam
 title: Getting Skype to work with weird webcams.
 ---
 

--- a/content/posts/2009-02-28-convergence.md
+++ b/content/posts/2009-02-28-convergence.md
@@ -9,7 +9,7 @@ tags:
 - Networking
 - Personal
 - Social Media
-- business
+- Business
 title: Convergence
 ---
 

--- a/content/posts/2009-02-28-testing-the-gnome-blog-panel-thingy.md
+++ b/content/posts/2009-02-28-testing-the-gnome-blog-panel-thingy.md
@@ -7,7 +7,7 @@ slug: testing-the-gnome-blog-panel-thingy
 tags:
 - Desktop
 - Laptop
-- installation
+- Installation
 title: Testing The Gnome Blog Panel Thingy
 ---
 

--- a/content/posts/2009-03-01-new-productivity-mantra.md
+++ b/content/posts/2009-03-01-new-productivity-mantra.md
@@ -9,7 +9,7 @@ tags:
 - Education
 - Networking
 - Productivity
-- work-life balance
+- Work-Life Balance
 title: New Productivity Mantra
 ---
 

--- a/content/posts/2009-04-04-set-up-and-running-of-dns-tunnelling-on-mbwe.md
+++ b/content/posts/2009-04-04-set-up-and-running-of-dns-tunnelling-on-mbwe.md
@@ -16,7 +16,7 @@ tags:
 - Programming
 - SSH
 - Storage
-- coding
+- Coding
 - port forwarding
 title: Set up and running of DNS tunnelling on MBWE
 ---

--- a/content/posts/2009-04-07-work-thought-of-the-day.md
+++ b/content/posts/2009-04-07-work-thought-of-the-day.md
@@ -5,7 +5,7 @@ comments: false
 date: 2009-04-07 11:31:57+00:00
 slug: work-thought-of-the-day
 tags:
-- Web post
+- Web Post
 title: Work Thought Of The Day
 ---
 

--- a/content/posts/2009-05-13-staggering-unproductivity.md
+++ b/content/posts/2009-05-13-staggering-unproductivity.md
@@ -14,7 +14,7 @@ tags:
 - Ubuntu
 - VirtualBox
 - Windows
-- development
+- Development
 title: Staggering Unproductivity
 ---
 

--- a/content/posts/2009-05-27-scala-euler-problem1.md
+++ b/content/posts/2009-05-27-scala-euler-problem1.md
@@ -8,7 +8,7 @@ tags:
 - GitHub
 - Programming
 - Scala
-- mathematics
+- Mathematics
 title: Scala-Euler Problem1
 ---
 

--- a/content/posts/2009-07-12-best-laid-plans-of-mice-and-men.md
+++ b/content/posts/2009-07-12-best-laid-plans-of-mice-and-men.md
@@ -16,7 +16,7 @@ tags:
 - Storage
 - VPN
 - WiFi
-- webcam
+- Webcam
 title: Best Laid Plans of Mice and Men
 ---
 

--- a/content/posts/2009-07-13-delayed-post-how-i-installed-windows-7-from-usb-hdd.md
+++ b/content/posts/2009-07-13-delayed-post-how-i-installed-windows-7-from-usb-hdd.md
@@ -11,7 +11,7 @@ tags:
 - Storage
 - USB
 - Windows
-- lenovo
+- Lenovo
 title: 'Delayed Post: How I Installed Windows 7 From USB HDD'
 ---
 

--- a/content/posts/2009-07-13-delayed-post-lenovo-rocks.md
+++ b/content/posts/2009-07-13-delayed-post-lenovo-rocks.md
@@ -10,8 +10,7 @@ tags:
 - Lenovo
 - Storage
 - Technology
-- customer service
-- lenovo
+- Customer Service
 title: 'Delayed Post: LENOVO ROCKS'
 ---
 

--- a/content/posts/2009-11-09-lenovo-not-so-rocking-anymore.md
+++ b/content/posts/2009-11-09-lenovo-not-so-rocking-anymore.md
@@ -4,7 +4,7 @@ date: 2009-11-09 17:34:56+00:00
 slug: lenovo-not-so-rocking-anymore
 tags:
 - Lenovo
-- customer service
+- Customer Service
 title: Lenovo, not so rocking anymore
 ---
 

--- a/content/posts/2009-12-31-new-years-resolutions.md
+++ b/content/posts/2009-12-31-new-years-resolutions.md
@@ -9,8 +9,8 @@ tags:
 - Open Source
 - Personal
 - Programming
-- blogging
-- freelancing
+- Blogging
+- Freelancing
 title: New Years Resolutions
 ---
 

--- a/content/posts/2010-01-17-are-we-on-the-brink-of-war.md
+++ b/content/posts/2010-01-17-are-we-on-the-brink-of-war.md
@@ -13,7 +13,6 @@ tags:
 - Hacking
 - Networking
 - Technology
-- cybersecurity
 title: Are we on the brink of War?
 ---
 

--- a/content/posts/2010-01-20-shared-items-20012010.md
+++ b/content/posts/2010-01-20-shared-items-20012010.md
@@ -7,7 +7,7 @@ tags:
 - Programming
 - Social Media
 - Statistics
-- web design
+- Web Design
 title: Shared Items - 20/01/2010
 ---
 

--- a/content/posts/2010-01-24-ubuntu-windows-sharing-a-dropbox-folder-on-ntfs.md
+++ b/content/posts/2010-01-24-ubuntu-windows-sharing-a-dropbox-folder-on-ntfs.md
@@ -10,9 +10,8 @@ tags:
 - Storage
 - Ubuntu
 - Windows
-- dropbox
+- Dropbox
 - dual-boot
-- storage
 title: Ubuntu / Windows Sharing a Dropbox folder on NTFS
 ---
 

--- a/content/posts/2010-01-24-ubuntu-windows-sharing-a-dropbox-folder-on-ntfs.md
+++ b/content/posts/2010-01-24-ubuntu-windows-sharing-a-dropbox-folder-on-ntfs.md
@@ -11,7 +11,7 @@ tags:
 - Ubuntu
 - Windows
 - Dropbox
-- dual-boot
+- Dual Boot
 title: Ubuntu / Windows Sharing a Dropbox folder on NTFS
 ---
 

--- a/content/posts/2010-01-25-online-media-marketing.md
+++ b/content/posts/2010-01-25-online-media-marketing.md
@@ -9,7 +9,7 @@ tags:
 - Marketing
 - Social Media
 - advertising
-- seo
+- SEO
 title: Online Media Marketing
 ---
 

--- a/content/posts/2010-02-03-shared-items-03022010.md
+++ b/content/posts/2010-02-03-shared-items-03022010.md
@@ -8,8 +8,8 @@ tags:
 - Programming
 - Social Media
 - WiFi
-- dual boot
-- freelancing
+- Dual Boot
+- Freelancing
 title: Shared Items - 03/02/2010
 ---
 

--- a/content/posts/2010-02-10-shared-items-10022010.md
+++ b/content/posts/2010-02-10-shared-items-10022010.md
@@ -11,7 +11,7 @@ tags:
 - Privacy
 - Technology
 - events
-- freelancing
+- Freelancing
 title: Shared Items - 10/02/2010
 ---
 

--- a/content/posts/2010-03-10-so-what-can-you-do-with-32-million-passwords.md
+++ b/content/posts/2010-03-10-so-what-can-you-do-with-32-million-passwords.md
@@ -14,7 +14,6 @@ tags:
 - Linux
 - Networking
 - QUB
-- cybersecurity
 title: So what can you do with 32 Million Passwords...
 ---
 

--- a/content/posts/2010-03-12-gsoc-or-having-a-go-at-network-simulator.md
+++ b/content/posts/2010-03-12-gsoc-or-having-a-go-at-network-simulator.md
@@ -16,8 +16,8 @@ tags:
 - Programming
 - Simulation
 - Ubuntu
-- configuration
-- installation
+- Configuration
+- Installation
 - virtualisation
 title: GSOC or Having a go at Network Simulator
 ---

--- a/content/posts/2010-03-13-ercurial-quick-start-cheatsheet.md
+++ b/content/posts/2010-03-13-ercurial-quick-start-cheatsheet.md
@@ -11,8 +11,7 @@ tags:
 - Tutorial
 - Ubuntu
 - Version Control
-- development
-- version control
+- Development
 title: Mercurial Quick Start Cheatsheet
 ---
 

--- a/content/posts/2010-03-23-chmod-on-lots-of-files.md
+++ b/content/posts/2010-03-23-chmod-on-lots-of-files.md
@@ -9,7 +9,7 @@ tags:
 - Embedded Systems
 - Linux
 - Storage
-- file management
+- File Management
 title: Chmod on lots of files
 ---
 

--- a/content/posts/2010-04-16-shaded-headers.md
+++ b/content/posts/2010-04-16-shaded-headers.md
@@ -10,7 +10,7 @@ tags:
 - Tutorial
 - WordPress
 - jQuery
-- web-design
+- Web Design
 title: Shaded Headers in Thematic
 ---
 

--- a/content/posts/2010-05-04-ubuntu-boosting-blog-hits.md
+++ b/content/posts/2010-05-04-ubuntu-boosting-blog-hits.md
@@ -7,7 +7,7 @@ slug: ubuntu-boosting-blog-hits
 tags:
 - Google
 - Ubuntu
-- seo
+- SEO
 title: Ubuntu Boosting Blog Hits
 ---
 

--- a/content/posts/2010-06-01-customised-user-directories-in-ubuntu.md
+++ b/content/posts/2010-06-01-customised-user-directories-in-ubuntu.md
@@ -12,7 +12,7 @@ tags:
 - Ubuntu
 - Configuration
 - Dropbox
-- file management
+- File Management
 title: Customised User Directories in Ubuntu
 ---
 

--- a/content/posts/2010-06-01-customised-user-directories-in-ubuntu.md
+++ b/content/posts/2010-06-01-customised-user-directories-in-ubuntu.md
@@ -10,8 +10,8 @@ tags:
 - Linux
 - Shell
 - Ubuntu
-- configuration
-- dropbox
+- Configuration
+- Dropbox
 - file management
 title: Customised User Directories in Ubuntu
 ---

--- a/content/posts/2010-06-24-great-hopes.md
+++ b/content/posts/2010-06-24-great-hopes.md
@@ -12,7 +12,7 @@ tags:
 - Speaking
 - Technology
 - social
-- tech
+- Tech
 title: Great HOPEs
 ---
 

--- a/content/posts/2010-07-08-intel-4965-poor-wireless-performance-under-ubuntu.md
+++ b/content/posts/2010-07-08-intel-4965-poor-wireless-performance-under-ubuntu.md
@@ -9,7 +9,7 @@ tags:
 - Networking
 - Ubuntu
 - WiFi
-- lenovo
+- Lenovo
 title: 'Intel 4965: Poor wireless performance under Ubuntu'
 ---
 

--- a/content/posts/2010-07-17-belfast_hackerspace.md
+++ b/content/posts/2010-07-17-belfast_hackerspace.md
@@ -16,7 +16,7 @@ tags:
 - Music
 - Open Source
 - Technology
-- creativity
+- Creativity
 - social
 title: Belfast Hackerspace Anyone?
 ---

--- a/content/posts/2010-09-07-news-from-the-belfast-hackerspace.md
+++ b/content/posts/2010-09-07-news-from-the-belfast-hackerspace.md
@@ -8,7 +8,6 @@ tags:
 - Belfast
 - Community
 - Cryptography
-- CyberSecurity
 - Cybersecurity
 - Hackerspace
 - Hacking
@@ -17,8 +16,8 @@ tags:
 - Programming
 - Technology
 - WiFi
-- charity
-- event
+- Charity
+- Event
 title: News from the Belfast Hackerspace
 ---
 

--- a/content/posts/2010-10-14-hackathon.md
+++ b/content/posts/2010-10-14-hackathon.md
@@ -16,7 +16,7 @@ tags:
 - Privacy
 - Programming
 - Technology
-- event
+- Event
 title: Hackathon
 ---
 

--- a/content/posts/2010-10-23-what-the-hack.md
+++ b/content/posts/2010-10-23-what-the-hack.md
@@ -10,7 +10,7 @@ tags:
 - Hacking
 - Networking
 - Technology
-- event
+- Event
 title: What the Hack?
 ---
 

--- a/content/posts/2011-02-12-bolsters-code-related-rants-an-ongoing-collection.md
+++ b/content/posts/2011-02-12-bolsters-code-related-rants-an-ongoing-collection.md
@@ -8,9 +8,9 @@ tags:
 - Opinion
 - Programming
 - Rant
-- development
+- Development
 - file management
-- version control
+- Version Control
 title: Bolsters Code-Related Rants (An ongoing collection)
 ---
 

--- a/content/posts/2011-02-12-bolsters-code-related-rants-an-ongoing-collection.md
+++ b/content/posts/2011-02-12-bolsters-code-related-rants-an-ongoing-collection.md
@@ -9,7 +9,7 @@ tags:
 - Programming
 - Rant
 - Development
-- file management
+- File Management
 - Version Control
 title: Bolsters Code-Related Rants (An ongoing collection)
 ---

--- a/content/posts/2011-02-23-stuff-ive-found-interesting-in-the-past-month-23022011.md
+++ b/content/posts/2011-02-23-stuff-ive-found-interesting-in-the-past-month-23022011.md
@@ -6,7 +6,7 @@ date: 2011-02-23 09:00:53+00:00
 slug: stuff-ive-found-interesting-in-the-past-month-23022011
 tags:
 - Social Media
-- entertainment
+- Entertainment
 title: Stuff I've found interesting in the past month - 23/02/2011
 ---
 

--- a/content/posts/2011-04-07-why-belfast-needs-a-hackerspace.md
+++ b/content/posts/2011-04-07-why-belfast-needs-a-hackerspace.md
@@ -13,7 +13,7 @@ tags:
 - Personal
 - Privacy
 - Technology
-- entrepreneurship
+- Entrepreneurship
 title: Why Belfast Needs a Hackerspace
 ---
 

--- a/content/posts/2011-07-23-stuff-ive-found-interesting-in-the-past-month-23072011-2.md
+++ b/content/posts/2011-07-23-stuff-ive-found-interesting-in-the-past-month-23072011-2.md
@@ -7,7 +7,7 @@ slug: stuff-ive-found-interesting-in-the-past-month-23072011-2
 tags:
 - Music
 - Star Wars
-- comedy
+- Comedy
 title: Stuff I've found interesting in the past month - 23/07/2011
 ---
 

--- a/content/posts/2011-07-28-the-road-to-coreboot-part-the-first-introduction.md
+++ b/content/posts/2011-07-28-the-road-to-coreboot-part-the-first-introduction.md
@@ -10,7 +10,6 @@ tags:
 - Embedded Systems
 - IRC
 - Open Source
-- embedded systems
 title: 'The Road to Coreboot, Part the First: Introduction'
 ---
 

--- a/content/posts/2011-10-05-vim-latex-suite-install-on-ubuntu.md
+++ b/content/posts/2011-10-05-vim-latex-suite-install-on-ubuntu.md
@@ -8,7 +8,7 @@ tags:
 - Linux
 - Ubuntu
 - latex
-- package management
+- Package Management
 title: Vim Latex Suite Install on Ubuntu
 ---
 

--- a/content/posts/2011-10-19-mendeley-repeated-citations-in-bibtex-library.md
+++ b/content/posts/2011-10-19-mendeley-repeated-citations-in-bibtex-library.md
@@ -6,7 +6,7 @@ date: 2011-10-19 08:58:30+00:00
 slug: mendeley-repeated-citations-in-bibtex-library
 tags:
 - latex
-- mendeley
+- Mendeley
 title: Mendeley Repeated Citations in BibTeX Library
 ---
 

--- a/content/posts/2011-10-26-unicode-characters-in-mendeley-bibliography-breaking-latex.md
+++ b/content/posts/2011-10-26-unicode-characters-in-mendeley-bibliography-breaking-latex.md
@@ -6,7 +6,7 @@ date: 2011-10-26 13:45:59+00:00
 slug: unicode-characters-in-mendeley-bibliography-breaking-latex
 tags:
 - latex
-- mendeley
+- Mendeley
 title: Unicode Characters in Mendeley Bibliography Breaking Latex?
 ---
 

--- a/content/posts/2011-12-08-guide-to-expanding-oracle-virtualbox-drives.md
+++ b/content/posts/2011-12-08-guide-to-expanding-oracle-virtualbox-drives.md
@@ -7,7 +7,7 @@ slug: guide-to-expanding-oracle-virtualbox-drives
 tags:
 - Linux
 - Windows
-- virtualbox
+- VirtualBox
 - virtualisation
 title: Guide to Expanding Oracle Virtualbox Drives
 ---

--- a/content/posts/2011-12-08-guide-to-persistent-reverse-ssh-shells-and-port-forwards.md
+++ b/content/posts/2011-12-08-guide-to-persistent-reverse-ssh-shells-and-port-forwards.md
@@ -10,7 +10,7 @@ tags:
 - Networking
 - Ubuntu
 - port forwarding
-- ssh
+- SSH
 title: Guide to Persistent Reverse SSH Shells and Port Forwards
 ---
 

--- a/content/posts/2011-12-31-ringing-in-the-new-year-by-seeing-out-the-old.md
+++ b/content/posts/2011-12-31-ringing-in-the-new-year-by-seeing-out-the-old.md
@@ -20,7 +20,7 @@ tags:
 - QUB
 - Rant
 - Travel
-- work-life balance
+- Work-Life Balance
 title: Ringing in the New Year by seeing out the old
 ---
 

--- a/content/posts/2012-04-10-k8055-usb-python-twitter-irc-space-indicator-as-a-os-service.md
+++ b/content/posts/2012-04-10-k8055-usb-python-twitter-irc-space-indicator-as-a-os-service.md
@@ -10,7 +10,7 @@ tags:
 - Social Media
 - USB
 - Ubuntu
-- irc
+- IRC
 title: 'K8055 USB + Python + Twitter + IRC: Space Indicator as a OS Service'
 ---
 

--- a/content/posts/2012-04-10-python-irclib-for-irc-status-updates.md
+++ b/content/posts/2012-04-10-python-irclib-for-irc-status-updates.md
@@ -12,7 +12,6 @@ tags:
 - Programming
 - Python
 - Ubuntu
-- irc
 title: Python + irclib for IRC Status Updates
 ---
 

--- a/content/posts/2012-04-30-ns-3-click-integration.md
+++ b/content/posts/2012-04-30-ns-3-click-integration.md
@@ -7,7 +7,7 @@ slug: ns-3-click-integration
 tags:
 - Linux
 - Simulation
-- configuration
+- Configuration
 title: NS-3 Click integration
 ---
 

--- a/content/posts/2012-07-20-the-concept-of-quality-and-my-mission.md
+++ b/content/posts/2012-07-20-the-concept-of-quality-and-my-mission.md
@@ -5,7 +5,7 @@ comments: true
 date: 2012-07-20 08:10:41+00:00
 slug: the-concept-of-quality-and-my-mission
 tags:
-- Personal development
+- Personal Development
 title: The concept of Quality and my 'mission'
 ---
 

--- a/content/posts/2012-09-10-4g-and-the-northern-ireland-problem.md
+++ b/content/posts/2012-09-10-4g-and-the-northern-ireland-problem.md
@@ -10,7 +10,7 @@ tags:
 - Northern Ireland
 - Technology
 - mobile
-- r&d
+- R&D
 title: 4G and 'The Northern Ireland Problem'
 ---
 

--- a/content/posts/2012-10-11-idiots-guide-to-updating-nexus-7-to-latest-rom.md
+++ b/content/posts/2012-10-11-idiots-guide-to-updating-nexus-7-to-latest-rom.md
@@ -10,7 +10,7 @@ tags:
 - Cybersecurity
 - Network Security
 - WiFi
-- backup
+- Backup
 title: Idiots Guide to Updating Nexus 7 to Latest ROM
 ---
 

--- a/content/posts/2013-02-11-it-qub-are-moving-forward.md
+++ b/content/posts/2013-02-11-it-qub-are-moving-forward.md
@@ -9,7 +9,7 @@ tags:
 - Networking
 - QUB
 - WiFi
-- vpn
+- VPN
 title: IT @ QUB are moving forward
 ---
 

--- a/content/posts/2013-04-10-abracadabra-ni-assemblys-plans-to-have-60-more-phd-researchers.md
+++ b/content/posts/2013-04-10-abracadabra-ni-assemblys-plans-to-have-60-more-phd-researchers.md
@@ -13,8 +13,8 @@ tags:
 - QUB
 - STEM
 - Technology
-- mathematics
-- science
+- Mathematics
+- Science
 title: Abracadabra - NI Assembly's Plans to have 60% more PhD Researchers
 ---
 

--- a/content/posts/2013-04-26-mercurial-to-git-transfer-problems-and-pitfalls.md
+++ b/content/posts/2013-04-26-mercurial-to-git-transfer-problems-and-pitfalls.md
@@ -9,7 +9,6 @@ tags:
 - Git
 - GitHub
 - Version Control
-- version control
 title: Mercurial to Git transfer; problems, and pitfalls.
 ---
 

--- a/content/posts/2013-06-20-so-long-and-thanks-for-all-the-fish.md
+++ b/content/posts/2013-06-20-so-long-and-thanks-for-all-the-fish.md
@@ -18,7 +18,7 @@ tags:
 - UK
 - University of Liverpool
 - funding
-- maritime
+- Maritime
 title: So long and thanks for all the fish
 ---
 

--- a/content/posts/2013-07-06-ssh-persistence-redux-multiple-sites-and-crontab-laziness.md
+++ b/content/posts/2013-07-06-ssh-persistence-redux-multiple-sites-and-crontab-laziness.md
@@ -11,8 +11,8 @@ tags:
 - Networking
 - Raspberry Pi
 - Shell
-- remote access
-- ssh
+- Remote Access
+- SSH
 title: 'SSH Persistence Redux: Multiple sites and Crontab Laziness'
 ---
 

--- a/content/posts/2014-01-20-unicode-madness-in-jekyll.md
+++ b/content/posts/2014-01-20-unicode-madness-in-jekyll.md
@@ -4,8 +4,8 @@ cover:
 date: 2014-01-20 00:00:00+00:00
 tags:
 - Jekyll
-- blogging
-- irc
+- Blogging
+- IRC
 title: Unicode Madness in Jekyll
 ---
 

--- a/content/posts/2014-05-21-translink-its-things-like-this-that-remind-me-why-you-suck-so-hard.md
+++ b/content/posts/2014-05-21-translink-its-things-like-this-that-remind-me-why-you-suck-so-hard.md
@@ -6,7 +6,7 @@ tags:
 - Belfast
 - Opinion
 - Rant
-- web post
+- Web Post
 title: Translink, it's things like this that remind me why you suck so hard
 ---
 

--- a/content/posts/2015-05-23-data-wrangling-for-uk-internet-usage.md
+++ b/content/posts/2015-05-23-data-wrangling-for-uk-internet-usage.md
@@ -7,8 +7,8 @@ tags:
 - Python
 - Statistics
 - UK
-- data visualization
-- notebook
+- Data Visualization
+- Notebook
 title: Data Wrangling for UK Internet Usage
 ---
 

--- a/content/posts/2018-10-22-daily-dated-untitled-jupyter-notebooks.md
+++ b/content/posts/2018-10-22-daily-dated-untitled-jupyter-notebooks.md
@@ -10,7 +10,7 @@ tags:
 - Open Data
 - Python
 - Coding
-- file-management
+- File Management
 - Notebook
 title: Daily Dated Untitled Jupyter Notebooks
 ---

--- a/content/posts/2018-10-22-daily-dated-untitled-jupyter-notebooks.md
+++ b/content/posts/2018-10-22-daily-dated-untitled-jupyter-notebooks.md
@@ -9,9 +9,9 @@ tags:
 - Jupyter
 - Open Data
 - Python
-- coding
+- Coding
 - file-management
-- notebook
+- Notebook
 title: Daily Dated Untitled Jupyter Notebooks
 ---
 

--- a/content/posts/2018-10-23-unfeeling-fire.md
+++ b/content/posts/2018-10-23-unfeeling-fire.md
@@ -12,7 +12,7 @@ tags:
 - Privacy
 - Robotics
 - Technology
-- ethics
+- Ethics
 title: Unfeeling Fire
 ---
 

--- a/content/posts/2020-03-04-the-importance-of-active-learning-in-data-science-and-engineering.md
+++ b/content/posts/2020-03-04-the-importance-of-active-learning-in-data-science-and-engineering.md
@@ -6,7 +6,7 @@ tags:
 - Data Science
 - Machine Learning
 - STEM
-- cybersecurity
+- Cybersecurity
 - professional development
 title: The Importance of Active Learning in Data Science and Engineering
 ---

--- a/content/posts/2020-06-23-merging-git-repos-for-archival-purposes.md
+++ b/content/posts/2020-06-23-merging-git-repos-for-archival-purposes.md
@@ -5,7 +5,7 @@ date: 2020-06-23 14:32:00+01:00
 tags:
 - Bash
 - Git
-- version-control
+- Version Control
 title: Merging Git Repos for Archival Purposes
 ---
 

--- a/content/posts/2020-09-08-back-to-reality.md
+++ b/content/posts/2020-09-08-back-to-reality.md
@@ -10,7 +10,7 @@ tags:
 - Podcasts
 - Technology
 - Travel
-- blogging
+- Blogging
 - events
 title: Back to reality
 ---

--- a/content/posts/2020-10-19-tell-me-about-your-programmer.md
+++ b/content/posts/2020-10-19-tell-me-about-your-programmer.md
@@ -9,7 +9,7 @@ tags:
 - Science Fiction
 - Software Engineering
 - Technology
-- cybersecurity
+- Cybersecurity
 title: Tell me about your Programmer - Robopsychologist and other careers that don't
   exist (yet)
 typora-root-url: C:\Users\me\Documents\GitHub\andrewbolster.github.io\

--- a/content/posts/2021-06-10-response-to-tog-s-third-eviction.md
+++ b/content/posts/2021-06-10-response-to-tog-s-third-eviction.md
@@ -13,7 +13,7 @@ tags:
 - Rant
 - Social Media
 - Technology
-- charity
+- Charity
 - funding
 title: Response to TOG's Third Eviction
 ---

--- a/content/posts/2023-04-01-staycation2023.md
+++ b/content/posts/2023-04-01-staycation2023.md
@@ -7,7 +7,7 @@ tags:
 - DIY
 - Personal Development
 - Programming
-- Work-life Balance
+- Work-Life Balance
 title: StayCation2023
 ---
 

--- a/content/posts/2024-02-19-generative-ai-impact-on-software-development-and-security.md
+++ b/content/posts/2024-02-19-generative-ai-impact-on-software-development-and-security.md
@@ -13,7 +13,6 @@ tags:
 - LLM
 - Machine Learning
 - Software Development
-- cybersecurity
 title: 'Generative AI: Impact on Software Development and Security'
 ---
 

--- a/content/posts/2025-07-14-being-a-dorc-in-the-age-of-generative-ai.md
+++ b/content/posts/2025-07-14-being-a-dorc-in-the-age-of-generative-ai.md
@@ -12,8 +12,8 @@ tags:
 - AI
 - LLM
 - Machine Learning
-- ethics
-- software development
+- Ethics
+- Software Development
 title: Being a DORC in the age of Generative AI
 ---
 

--- a/content/posts/2026-04-28-the-code-doesnt-care-who-wrote-it.md
+++ b/content/posts/2026-04-28-the-code-doesnt-care-who-wrote-it.md
@@ -2,7 +2,7 @@
 title: "The Code Doesn't Care Who Wrote It: Why Context, Not AI Fear, Will Define Modern Application Security"
 date: 2026-04-28T00:00:00+00:00
 categories: [AI, Security]
-tags: [AI, application security, AppSec, DevOps, LLM, code generation, context, vibe coding, SAST, vulnerability management, Black Duck]
+tags: [AI, Application Security, AppSec, DevOps, LLM, code generation, context, vibe coding, SAST, vulnerability management, Black Duck]
 description: "Originally published on DevOps.com — why the AI authorship debate misses the real challenge in modern application security."
 ---
 


### PR DESCRIPTION
Two follow-ups found while doing #65, plus a third that surfaced during verification.

## 1. CLAUDE.md URL documentation

The "URL Structure" section documented `/:year/:month/:title.html`. `hugo.toml` has `posts = "/:year/:month/:title"` — no `.html`. It also omitted the behaviour that caused both permalink bugs in #65:

- **`:title` slugifies the post's TITLE, not its filename.** A shortened filename yields a URL that 404s. Checking a file exists is not verification.
- **Title punctuation survives into the slug** — a title ending in a full stop produces a trailing dot in the URL.
- **`slug:` is inert** under a `:title` pattern. Pinning a URL needs `url:`, plus `aliases:` if the old one was published.

## 2. Tag casing

45 tags existed in two or three casings — worst was `Cybersecurity` / `cybersecurity` / `CyberSecurity`.

**Correcting an earlier claim:** I had described this as splitting a tag "across three taxonomy pages." That was wrong, and I verified before changing anything. Hugo merges the variants into one term page: `/tags/cybersecurity/` serves all 36 posts, displays as "Cybersecurity", and appears once in the sitemap. Nothing was visibly broken by casing alone.

The genuine defect attached to it: **10 posts carried the same tag twice** under different casings. Removed.

Normalisation rule — Title Case as house style, with:

| Kind | Treatment | Examples |
|---|---|---|
| Acronyms | Uppercase | `IRC`, `SEO`, `SSH`, `VPN`, `R&D` |
| Proper nouns | As the vendor spells them | `Lenovo`, `Dropbox`, `Mendeley`, `VirtualBox` |
| Everything else | Title Case | `Blogging`, `Customer Service`, `Version Control` |

Chosen deliberately rather than by frequency — majority-wins would have picked `irc` over `IRC` and `seo` over `SEO`.

## 3. Slug-level collisions (found while verifying)

Grouping by lowercase was too weak. What determines the taxonomy page is the **slug**, and slugification collapses spaces and hyphens alike — so tags differing only by punctuation collide:

| Slug | Colliding values | Normalised to |
|---|---|---|
| `dual-boot` | `Dual Boot`, `dual-boot` | Dual Boot |
| `file-management` | `file management`, `file-management` | File Management |
| `version-control` | `Version Control`, `version-control` | Version Control |
| `web-design` | `Web Design`, `web-design` | Web Design |

These collisions pre-dated this PR, but commit `194e47d` shifted which side of the `version-control` one Hugo displayed, rendering it as "Version-Control". Commit `a4e959f` removes the collisions outright, fixing that regression **and** two pre-existing display bugs: production currently shows "File-Management" and "Irc".

Note `file management` had only one casing, so a case-only grouping never flagged it despite being half of a collision.

## Verification

Rendered pages on the deploy preview, compared against production:

| Term | Production | Preview |
|---|---|---|
| `version-control` | Version Control | Version Control |
| `file-management` | File-Management | **File Management** |
| `irc` | Irc | **IRC** |
| `seo` / `ssh` / `vpn` | SEO / SSH / VPN | unchanged |
| `cybersecurity` | Cybersecurity | unchanged |

Post counts per term identical to production (`cybersecurity` 36, `version-control` 8, `web-design` 5, `dual-boot` 4, `file-management` 4, `storage` 10) — nothing dropped.

- Zero slug-level collisions remain.
- All 233 posts re-parse as valid YAML.
- Both front-matter formats (inline `[...]` and block `- `) handled; diffs inspected.
- Categories were already consistent — untouched.
- Tag-page URLs are unchanged (already lowercase-slugified), so no aliases needed.

Scope note: only fragmented/colliding groups were touched. Single-casing tags such as `tokens` and `bubble` stay lowercase, keeping this a normalisation rather than a site-wide restyle.