### PR TITLE
Update /now/ page

### DIFF
--- a/content/now.md
+++ b/content/now.md
@@ -7,9 +7,12 @@ url: /now/
 
 Senior R&D Manager @ [Black Duck Software](https://blackduck.com/), driving data to make AI work.
 
+## Upcoming
+
+* Attending [Gartner Security & Risk Management Summit 2026](https://www.gartner.com/en/conferences/emea/security-risk-management-uk)
+
 ## Wants
 
-* [Sponsors for BSides Belfast 2026](https://bsidesbelfast.org/)
 * [Attendees for InfoSecNI](https://infosecni.net/)
 * [Supporters for Farset Labs](https://www.farsetlabs.org.uk/support/donate/)
 


### PR DESCRIPTION
Refreshes `content/now.md`, which had not been touched since 2026-02-02.

## Changes

- **Added an `Upcoming` section** with "Attending [Gartner Security & Risk Management Summit 2026](https://www.gartner.com/en/conferences/emea/security-risk-management-uk)". Placed in its own section rather than under `Wants`, since attending is a status rather than an ask.
- **Removed the BSides Belfast 2026 sponsor want**, now fulfilled. `Wants` is a plain bullet list rather than a checklist, so a satisfied want comes off it — happy to strike it through instead if you'd rather it stayed visible.

## Notes

- The Gartner URL is the same one already cited in `about.md` for the 2025 summit. Gartner returns 403 to command-line requests (bot blocking), so it can't be fetch-verified from here, but it is a known-good link in this repo.
- Editing the file refreshes the git-derived "Last updated" banner the `lastmod` shortcode renders — the page had been publicly displaying "Last updated: February 2, 2026", including in `og:description` and JSON-LD.

Further updates still under discussion and not included here.

---
_Generated by [Claude Code](https://claude.ai/code/session_016iqeWnTbfUEZBFfQmoyV69)_